### PR TITLE
Remove manual execution from segment tree tests

### DIFF
--- a/back/ONE/baselines-master/baselines-master/baselines/common/tests/test_segment_tree.py
+++ b/back/ONE/baselines-master/baselines-master/baselines/common/tests/test_segment_tree.py
@@ -94,10 +94,3 @@ def test_max_interval_tree():
     assert np.isclose(tree.min(2, -1), 4.0)
     assert np.isclose(tree.min(3, 4), 3.0)
 
-
-if __name__ == '__main__':
-    test_tree_set()
-    test_tree_set_overlap()
-    test_prefixsum_idx()
-    test_prefixsum_idx2()
-    test_max_interval_tree()


### PR DESCRIPTION
## Summary
- clean up `test_segment_tree.py` to rely solely on pytest

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*