### PR TITLE
Refactor segment tree tests to use pytest

### DIFF
--- a/back/ONE/baselines-master/baselines-master/baselines/common/tests/test_segment_tree.py
+++ b/back/ONE/baselines-master/baselines-master/baselines/common/tests/test_segment_tree.py
@@ -1,37 +1,49 @@
-import numpy as np
+import pytest
 
 from baselines.common.segment_tree import SumSegmentTree, MinSegmentTree
 
 
-def test_tree_set():
-    tree = SumSegmentTree(4)
+@pytest.fixture
+def sum_tree():
+    """Return a fresh SumSegmentTree with four elements."""
+    return SumSegmentTree(4)
+
+
+@pytest.fixture
+def min_tree():
+    """Return a fresh MinSegmentTree with four elements."""
+    return MinSegmentTree(4)
+
+
+def test_tree_set(sum_tree):
+    tree = sum_tree
 
     tree[2] = 1.0
     tree[3] = 3.0
 
-    assert np.isclose(tree.sum(), 4.0)
-    assert np.isclose(tree.sum(0, 2), 0.0)
-    assert np.isclose(tree.sum(0, 3), 1.0)
-    assert np.isclose(tree.sum(2, 3), 1.0)
-    assert np.isclose(tree.sum(2, -1), 1.0)
-    assert np.isclose(tree.sum(2, 4), 4.0)
+    assert tree.sum() == pytest.approx(4.0)
+    assert tree.sum(0, 2) == pytest.approx(0.0)
+    assert tree.sum(0, 3) == pytest.approx(1.0)
+    assert tree.sum(2, 3) == pytest.approx(1.0)
+    assert tree.sum(2, -1) == pytest.approx(1.0)
+    assert tree.sum(2, 4) == pytest.approx(4.0)
 
 
-def test_tree_set_overlap():
-    tree = SumSegmentTree(4)
+def test_tree_set_overlap(sum_tree):
+    tree = sum_tree
 
     tree[2] = 1.0
     tree[2] = 3.0
 
-    assert np.isclose(tree.sum(), 3.0)
-    assert np.isclose(tree.sum(2, 3), 3.0)
-    assert np.isclose(tree.sum(2, -1), 3.0)
-    assert np.isclose(tree.sum(2, 4), 3.0)
-    assert np.isclose(tree.sum(1, 2), 0.0)
+    assert tree.sum() == pytest.approx(3.0)
+    assert tree.sum(2, 3) == pytest.approx(3.0)
+    assert tree.sum(2, -1) == pytest.approx(3.0)
+    assert tree.sum(2, 4) == pytest.approx(3.0)
+    assert tree.sum(1, 2) == pytest.approx(0.0)
 
 
-def test_prefixsum_idx():
-    tree = SumSegmentTree(4)
+def test_prefixsum_idx(sum_tree):
+    tree = sum_tree
 
     tree[2] = 1.0
     tree[3] = 3.0
@@ -44,8 +56,8 @@ def test_prefixsum_idx():
     assert tree.find_prefixsum_idx(4.00) == 3
 
 
-def test_prefixsum_idx2():
-    tree = SumSegmentTree(4)
+def test_prefixsum_idx2(sum_tree):
+    tree = sum_tree
 
     tree[0] = 0.5
     tree[1] = 1.0
@@ -60,44 +72,37 @@ def test_prefixsum_idx2():
     assert tree.find_prefixsum_idx(5.50) == 3
 
 
-def test_max_interval_tree():
-    tree = MinSegmentTree(4)
+def test_max_interval_tree(min_tree):
+    tree = min_tree
 
     tree[0] = 1.0
     tree[2] = 0.5
     tree[3] = 3.0
 
-    assert np.isclose(tree.min(), 0.5)
-    assert np.isclose(tree.min(0, 2), 1.0)
-    assert np.isclose(tree.min(0, 3), 0.5)
-    assert np.isclose(tree.min(0, -1), 0.5)
-    assert np.isclose(tree.min(2, 4), 0.5)
-    assert np.isclose(tree.min(3, 4), 3.0)
+    assert tree.min() == pytest.approx(0.5)
+    assert tree.min(0, 2) == pytest.approx(1.0)
+    assert tree.min(0, 3) == pytest.approx(0.5)
+    assert tree.min(0, -1) == pytest.approx(0.5)
+    assert tree.min(2, 4) == pytest.approx(0.5)
+    assert tree.min(3, 4) == pytest.approx(3.0)
 
     tree[2] = 0.7
 
-    assert np.isclose(tree.min(), 0.7)
-    assert np.isclose(tree.min(0, 2), 1.0)
-    assert np.isclose(tree.min(0, 3), 0.7)
-    assert np.isclose(tree.min(0, -1), 0.7)
-    assert np.isclose(tree.min(2, 4), 0.7)
-    assert np.isclose(tree.min(3, 4), 3.0)
+    assert tree.min() == pytest.approx(0.7)
+    assert tree.min(0, 2) == pytest.approx(1.0)
+    assert tree.min(0, 3) == pytest.approx(0.7)
+    assert tree.min(0, -1) == pytest.approx(0.7)
+    assert tree.min(2, 4) == pytest.approx(0.7)
+    assert tree.min(3, 4) == pytest.approx(3.0)
 
     tree[2] = 4.0
 
-    assert np.isclose(tree.min(), 1.0)
-    assert np.isclose(tree.min(0, 2), 1.0)
-    assert np.isclose(tree.min(0, 3), 1.0)
-    assert np.isclose(tree.min(0, -1), 1.0)
-    assert np.isclose(tree.min(2, 4), 3.0)
-    assert np.isclose(tree.min(2, 3), 4.0)
-    assert np.isclose(tree.min(2, -1), 4.0)
-    assert np.isclose(tree.min(3, 4), 3.0)
+    assert tree.min() == pytest.approx(1.0)
+    assert tree.min(0, 2) == pytest.approx(1.0)
+    assert tree.min(0, 3) == pytest.approx(1.0)
+    assert tree.min(0, -1) == pytest.approx(1.0)
+    assert tree.min(2, 4) == pytest.approx(3.0)
+    assert tree.min(2, 3) == pytest.approx(4.0)
+    assert tree.min(2, -1) == pytest.approx(4.0)
+    assert tree.min(3, 4) == pytest.approx(3.0)
 
-
-if __name__ == '__main__':
-    test_tree_set()
-    test_tree_set_overlap()
-    test_prefixsum_idx()
-    test_prefixsum_idx2()
-    test_max_interval_tree()


### PR DESCRIPTION
## Summary
- convert manual tree creation to fixtures
- use `pytest.approx` for float comparisons

## Testing
- `pytest -q back/ONE/baselines-master/baselines-master/baselines/common/tests/test_segment_tree.py` *(fails: ModuleNotFoundError: No module named 'numpy')*